### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,10 +6,10 @@ taipan
 .. |Version| image:: https://img.shields.io/pypi/v/taipan.svg?style=flat
     :target: https://pypi.python.org/pypi/taipan
     :alt: Version
-.. |Development Status| image:: https://pypip.in/status/taipan/badge.svg?style=flat
+.. |Development Status| image:: https://img.shields.io/pypi/status/taipan.svg?style=flat
     :target: https://pypi.python.org/pypi/taipan/
     :alt: Development Status
-.. |Python Versions| image:: https://pypip.in/py_versions/taipan/badge.svg?style=flat
+.. |Python Versions| image:: https://img.shields.io/pypi/pyversions/taipan.svg?style=flat
     :target: https://pypi.python.org/pypi/taipan
     :alt: Python versions
 .. |License| image:: https://img.shields.io/pypi/l/taipan.svg?style=flat


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20taipan))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `taipan`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.